### PR TITLE
Add option to make identifiers uppercase by default

### DIFF
--- a/dialect/oracle/oracle.go
+++ b/dialect/oracle/oracle.go
@@ -26,7 +26,8 @@ func DialectOptions() *goqu.SQLDialectOptions {
 	opts.SurroundLimitWithParentheses = true
 
 	opts.PlaceHolderFragment = []byte(":")
-	opts.QuoteIdentifiers = false
+	opts.QuoteIdentifiers = true
+	opts.UppercaseIdentifiers = true
 	opts.IncludePlaceholderNum = true
 	opts.DefaultValuesFragment = []byte("")
 	opts.True = []byte("1")

--- a/sqlgen/expression_sql_generator.go
+++ b/sqlgen/expression_sql_generator.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -238,7 +239,11 @@ func (esg *expressionSQLGenerator) identifierExpressionSQL(b sb.SQLBuilder, iden
 		if esg.dialectOptions.QuoteIdentifiers {
 			b.WriteRunes(esg.dialectOptions.QuoteRune)
 		}
-		b.WriteStrings(schema)
+		if esg.dialectOptions.UppercaseIdentifiers {
+			b.WriteStrings(strings.ToUpper(schema))
+		} else {
+			b.WriteStrings(schema)
+		}
 		if esg.dialectOptions.QuoteIdentifiers {
 			b.WriteRunes(esg.dialectOptions.QuoteRune)
 		}
@@ -250,7 +255,11 @@ func (esg *expressionSQLGenerator) identifierExpressionSQL(b sb.SQLBuilder, iden
 		if esg.dialectOptions.QuoteIdentifiers {
 			b.WriteRunes(esg.dialectOptions.QuoteRune)
 		}
-		b.WriteStrings(table)
+		if esg.dialectOptions.UppercaseIdentifiers {
+			b.WriteStrings(strings.ToUpper(table))
+		} else {
+			b.WriteStrings(table)
+		}
 		if esg.dialectOptions.QuoteIdentifiers {
 			b.WriteRunes(esg.dialectOptions.QuoteRune)
 		}
@@ -265,7 +274,11 @@ func (esg *expressionSQLGenerator) identifierExpressionSQL(b sb.SQLBuilder, iden
 			if esg.dialectOptions.QuoteIdentifiers {
 				b.WriteRunes(esg.dialectOptions.QuoteRune)
 			}
-			b.WriteStrings(t)
+			if esg.dialectOptions.UppercaseIdentifiers {
+				b.WriteStrings(strings.ToUpper(t))
+			} else {
+				b.WriteStrings(t)
+			}
 			if esg.dialectOptions.QuoteIdentifiers {
 				b.WriteRunes(esg.dialectOptions.QuoteRune)
 			}

--- a/sqlgen/sql_dialect_options.go
+++ b/sqlgen/sql_dialect_options.go
@@ -135,9 +135,11 @@ type (
 		LateralFragment []byte
 		// The quote rune to use when quoting identifiers(DEFAULT='"')
 		QuoteRune rune
-		// The NULL literal to use when interpolating nulls values (DEFAULT=[]byte("NULL"))
+		// Whether or not to use the QuoteRune for identifiers (DEFAULT=true)
 		QuoteIdentifiers bool
-		// Whether or not to use the QuoteRune for identifiers
+		// Whether or not to upcase quoted QuoteIdentifiers (DEFAULT=false)
+		UppercaseIdentifiers bool
+		// The NULL literal to use when interpolating nulls values (DEFAULT=[]byte("NULL"))
 		Null []byte
 		// The TRUE literal to use when interpolating bool true values (DEFAULT=[]byte("TRUE"))
 		True []byte
@@ -493,6 +495,7 @@ func DefaultDialectOptions() *SQLDialectOptions {
 		Null:                      []byte("NULL"),
 		True:                      []byte("TRUE"),
 		False:                     []byte("FALSE"),
+		QuoteIdentifiers:          true,
 
 		PlaceHolderFragment: []byte("?"),
 		QuoteRune:           '"',


### PR DESCRIPTION
Adds an option to make identifiers automatically UPPER CASE to support Oracle. Oracle uses uppercase table/column names by default, even if the DDL statements name the tables using lowercase.