### PR TITLE
Omit offset clause when the offset is 0 and no limit is set

### DIFF
--- a/sqlgen/common_sql_generator.go
+++ b/sqlgen/common_sql_generator.go
@@ -113,11 +113,10 @@ func (csg *commonSQLGenerator) OrderWithOffsetFetchSQL(
 	}
 
 	csg.OrderSQL(b, order)
-	if offset >= 0 {
+	if limit != nil || offset > 0 {
 		b.Write(csg.dialectOptions.OffsetFragment)
 		csg.esg.Generate(b, offset)
 		b.Write([]byte(" ROWS"))
-
 	}
 	if limit != nil {
 		b.Write(csg.dialectOptions.FetchFragment)


### PR DESCRIPTION
Changes goqu's code generation to omit the `OFFSET` clause when the offset is 0 and no limit is set. This allows us to work around an issue with Oracle wherein `OFFSET` cannot be used in combination with `SELECT ... FOR UPDATE`.