### PR TITLE
Add SELECT FOR UPDATE support for sqlserver

### DIFF
--- a/dialect/sqlite3/sqlite3.go
+++ b/dialect/sqlite3/sqlite3.go
@@ -66,6 +66,8 @@ func DialectOptions() *goqu.SQLDialectOptions {
 	opts.ConflictDoUpdateFragment = []byte(" DO UPDATE SET ")
 	opts.ConflictDoNothingFragment = []byte(" DO NOTHING ")
 	opts.ForUpdateFragment = []byte("")
+	opts.SkipLockedFragment = []byte("")
+	opts.NowaitFragment = []byte("")
 	opts.OfFragment = []byte("")
 	opts.NowaitFragment = []byte("")
 	return opts

--- a/dialect/sqlserver/sqlserver.go
+++ b/dialect/sqlserver/sqlserver.go
@@ -90,6 +90,10 @@ func DialectOptions() *goqu.SQLDialectOptions {
 	opts.ConflictFragment = []byte("")
 	opts.ConflictDoUpdateFragment = []byte("")
 	opts.ConflictDoNothingFragment = []byte("")
+	opts.ForUpdateFragment = []byte(" WITH (UPDLOCK")
+	opts.ForUpdateEndFragment = []byte(")")
+	opts.NowaitFragment = []byte(", NOWAIT")
+	opts.SkipLockedFragment = []byte(", READPAST")
 
 	return opts
 }

--- a/sqlgen/select_sql_generator.go
+++ b/sqlgen/select_sql_generator.go
@@ -215,12 +215,13 @@ func (ssg *selectSQLGenerator) ForSQL(b sb.SQLBuilder, lockingClause exp.Lock) {
 	// SKIP LOCKED. There's no special syntax for it in PG, so we don't do anything for it here
 	switch lockingClause.WaitOption() {
 	case exp.Wait:
-		return
 	case exp.NoWait:
 		b.Write(ssg.DialectOptions().NowaitFragment)
 	case exp.SkipLocked:
 		b.Write(ssg.DialectOptions().SkipLockedFragment)
 	}
+
+	b.Write(ssg.DialectOptions().ForUpdateEndFragment)
 }
 
 func (ssg *selectSQLGenerator) WindowSQL(b sb.SQLBuilder, windows []exp.WindowExpression) {

--- a/sqlgen/sql_dialect_options.go
+++ b/sqlgen/sql_dialect_options.go
@@ -118,6 +118,8 @@ type (
 		// The SQL FOR UPDATE fragment(DEFAULT=[]byte(" FOR UPDATE "))
 		ForUpdateFragment []byte
 		// The SQL FOR NO KEY UPDATE fragment(DEFAULT=[]byte(" FOR NO KEY UPDATE "))
+		ForUpdateEndFragment []byte
+		// The SQL FOR UPDATE end fragment(DEFAULT=[]byte(""))
 		ForNoKeyUpdateFragment []byte
 		// The SQL FOR SHARE fragment(DEFAULT=[]byte(" FOR SHARE "))
 		ForShareFragment []byte


### PR DESCRIPTION
Adds `SELECT FOR UPDATE` support for sqlserver, including support for `NOWAIT` and `SKIP LOCKED` equivalents.